### PR TITLE
Adding U2FAPI.com

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -577,6 +577,13 @@ websites:
       sms: Yes
       doc: https://www.twilio.com/help/faq/twilio-basics/what-happens-when-i-enable-two-factor-authentication
 
+    - name: U2FAPI
+      url: https://u2fapi.com/
+      img: https://u2fapi.com/assets/img/icon.png
+      tfa: Yes
+      sms: No
+      doc: https://u2fapi.com/U2F%20API%20documentation.pdf
+      
     - name: Unfuddle
       url: https://unfuddle.com/
       img: unfuddle.png


### PR DESCRIPTION
Proposing U2FAPI.com to be added to list of developer related websites. 
- The image should be hosted local to your site, rather than linked remotely (will try to fix this)